### PR TITLE
remove declared dependencies on internally provided component

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,11 +9,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>redswallow</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>redswallow</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>redswallow</exec_depend>
 </package>


### PR DESCRIPTION
It shouldn't be declared as it's provided internally. If it's declared dependency resolution toolchains will fail.